### PR TITLE
feat(design): redesign esthétique — Fraunces + Syne, hero dramatique,…

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -5,6 +5,8 @@ import Navbar from './components/Navbar.tsx';
 import Hero from './components/Hero.tsx';
 import Footer from './components/Footer.tsx';
 import CookieConsent from './components/CookieConsent.tsx';
+import SectionHeader from './components/ui/SectionHeader.tsx';
+import Card from './components/ui/Card.tsx';
 import { ViewState, LanguageCode, ROUTE_MAP, VIEW_FROM_ROUTE } from './types.ts';
 import { AuthProvider } from './contexts/AuthContext.tsx';
 import { AlertTriangle, RefreshCcw, ArrowRight, Utensils, Home, Scale, Users, BookOpen } from 'lucide-react';
@@ -25,24 +27,23 @@ import { FoodSupplierForm, FoodNetworkForm } from './components/FoodForms.tsx';
 import LegalDocSection from './components/LegalDocSection.tsx';
 import PressSection from './components/PressSection.tsx';
 
-// Page titles for SEO — keyed by route path
 const PAGE_TITLES: Record<string, string> = {
-  '/':                       'BALLAL ASBL | Solidarité Guinée-Belgique',
-  '/entraide':               'Entraide & Solidarité | BALLAL ASBL',
-  '/logement':               'Logement & Squat | BALLAL ASBL',
-  '/culture':                'Culture & Histoire | BALLAL ASBL',
-  '/droits':                 'Aide & Droits | BALLAL ASBL',
-  '/alimentation':           'Projet Alimentaire | BALLAL ASBL',
+  '/':                         'BALLAL ASBL | Solidarité Guinée-Belgique',
+  '/entraide':                 'Entraide & Solidarité | BALLAL ASBL',
+  '/logement':                 'Logement & Squat | BALLAL ASBL',
+  '/culture':                  'Culture & Histoire | BALLAL ASBL',
+  '/droits':                   'Aide & Droits | BALLAL ASBL',
+  '/alimentation':             'Projet Alimentaire | BALLAL ASBL',
   '/alimentation/fournisseur': 'Fournisseur Alimentaire | BALLAL ASBL',
-  '/alimentation/collectif': 'Collectif Alimentaire | BALLAL ASBL',
-  '/equipe':                 'Équipe | BALLAL ASBL',
-  '/festival':               'Festival Sans-Papiers | BALLAL ASBL',
-  '/don':                    'Faire un Don | BALLAL ASBL',
-  '/partager':               'Partager | BALLAL ASBL',
-  '/contact':                'Contact | BALLAL ASBL',
-  '/confidentialite':        'Politique de Confidentialité | BALLAL ASBL',
-  '/mentions-legales':       'Mentions Légales | BALLAL ASBL',
-  '/presse':                 'Espace Presse | BALLAL ASBL',
+  '/alimentation/collectif':   'Collectif Alimentaire | BALLAL ASBL',
+  '/equipe':                   'Équipe | BALLAL ASBL',
+  '/festival':                 'Festival Sans-Papiers | BALLAL ASBL',
+  '/don':                      'Faire un Don | BALLAL ASBL',
+  '/partager':                 'Partager | BALLAL ASBL',
+  '/contact':                  'Contact | BALLAL ASBL',
+  '/confidentialite':          'Politique de Confidentialité | BALLAL ASBL',
+  '/mentions-legales':         'Mentions Légales | BALLAL ASBL',
+  '/presse':                   'Espace Presse | BALLAL ASBL',
 };
 
 interface ErrorBoundaryProps { children?: ReactNode; }
@@ -61,19 +62,19 @@ class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
   render() {
     if (this.state.hasError) {
       return (
-        <div className="min-h-[50vh] flex flex-col items-center justify-center p-8 text-center bg-[#BE0000]/5 m-4 rounded-[12px] border border-[#BE0000]/15">
-          <AlertTriangle className="h-12 w-12 text-[#BE0000] mb-4" />
+        <div className="min-h-[50vh] flex flex-col items-center justify-center p-8 text-center bg-guinea-red/5 m-4 rounded-token-lg border border-guinea-red/15">
+          <AlertTriangle className="h-12 w-12 text-guinea-red mb-4" />
           <h2 className="text-xl font-bold mb-2">Une erreur est survenue</h2>
           {this.state.errorMessage && (
-            <p className="text-sm text-[#6B6B6B] mb-4 font-mono bg-white px-3 py-2 rounded border border-[#E8E8E6]">
+            <p className="text-body-sm text-ink-muted mb-4 font-mono bg-white px-3 py-2 rounded-token border border-border-subtle">
               {this.state.errorMessage}
             </p>
           )}
           <button
             onClick={() => window.location.reload()}
-            className="flex items-center px-4 py-2 bg-[#BE0000] text-white rounded-[8px] font-bold hover:bg-[#9B0000] transition-colors"
+            className="inline-flex items-center gap-2 px-4 py-2 bg-guinea-red text-white rounded-token font-bold hover:bg-guinea-red-dark transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-guinea-red/50 focus-visible:ring-offset-2"
           >
-            <RefreshCcw className="mr-2 h-4 w-4" /> Recharger
+            <RefreshCcw className="h-4 w-4" aria-hidden="true" /> Recharger
           </button>
         </div>
       );
@@ -82,40 +83,40 @@ class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
   }
 }
 
-// ── Programme data ─────────────────────────────────────────────────────────
+// ── Données programmes ─────────────────────────────────────────────────────
 const PROGRAMS = [
   {
     view:        ViewState.LEGAL_AID,
     icon:        Scale,
-    borderColor: '#BE0000',
-    iconBg:      'bg-[#BE0000]/10',
-    iconColor:   'text-[#BE0000]',
+    borderColor: 'var(--crimson)',
+    iconBg:      'bg-guinea-red/10',
+    iconColor:   'text-guinea-red',
     label:       'Droits & Juridique',
     desc:        "Votre domicile est protégé par la Constitution. Articles 9bis/9ter, scripts d'urgence, régularisation — nous vous outillons pour vous défendre.",
   },
   {
     view:        ViewState.SQUAT,
     icon:        Home,
-    borderColor: '#0F0F0F',
-    iconBg:      'bg-[#0F0F0F]/8',
-    iconColor:   'text-[#0F0F0F]',
+    borderColor: 'var(--ink)',
+    iconBg:      'bg-ink/10',
+    iconColor:   'text-ink',
     label:       'Logement',
     desc:        "Nous gérons directement plusieurs occupations solidaires à Bruxelles depuis des années. Pas des conseils de l'extérieur — une présence physique, sur place, chaque jour.",
   },
   {
     view:        ViewState.FOOD_AUTONOMY,
     icon:        Utensils,
-    borderColor: '#00843D',
-    iconBg:      'bg-[#00843D]/10',
-    iconColor:   'text-[#00843D]',
+    borderColor: 'var(--emerald)',
+    iconBg:      'bg-guinea-green/10',
+    iconColor:   'text-guinea-green',
     label:       'Autonomie Alimentaire',
     desc:        "Chaque semaine, nous transformons les invendus en repas. Réseau de fournisseurs et cuisines collectives à Bruxelles.",
   },
   {
     view:        ViewState.SOLIDARITY_NETWORK,
     icon:        Users,
-    borderColor: '#FFCC00',
-    iconBg:      'bg-[#FFCC00]/20',
+    borderColor: 'var(--gold)',
+    iconBg:      'bg-guinea-yellow/20',
     iconColor:   'text-[#8B7000]',
     label:       'Entraide',
     desc:        "Trouver du travail, comprendre un document, naviguer dans les administrations — quelqu'un qui est passé par là change tout. C'est ce que nous faisons.",
@@ -123,19 +124,19 @@ const PROGRAMS = [
   {
     view:        ViewState.CULTURE,
     icon:        BookOpen,
-    borderColor: '#4B3D8F',
-    iconBg:      'bg-[#4B3D8F]/10',
-    iconColor:   'text-[#4B3D8F]',
+    borderColor: 'var(--ink)',
+    iconBg:      'bg-ink/10',
+    iconColor:   'text-ink',
     label:       'Culture & Histoire',
     desc:        "La culture est notre levier politique. Elle nous rend visibles, renforce notre voix et nous permet d'aller plus loin encore dans ce que nous construisons.",
   },
 ];
 
 const IMPACT_NUMBERS = [
-  { value: '15 000+', label: 'Guinéens en Belgique',    accent: '#BE0000' },
-  { value: '5',       label: 'Programmes actifs',        accent: '#FFCC00' },
-  { value: '3',       label: "Langues d'assistance",     accent: '#00843D' },
-  { value: '24h',     label: "Ligne d'urgence",          accent: '#BE0000' },
+  { value: '15 000+', label: 'Guinéens en Belgique',  accent: 'var(--crimson)' },
+  { value: '5',       label: 'Programmes actifs',      accent: 'var(--gold)'    },
+  { value: '3',       label: "Langues d'assistance",   accent: 'var(--emerald)' },
+  { value: '24h',     label: "Ligne d'urgence",        accent: 'var(--crimson)' },
 ];
 
 const cardVariants = {
@@ -145,6 +146,14 @@ const cardVariants = {
     transition: { delay: i * 0.07, duration: 0.45, ease: [0.22, 1, 0.36, 1] as const },
   }),
 };
+
+const TEAM_MEMBERS = [
+  { name: "Thierno I. T. Diallo", bio: "Président fondateur",    img: "https://i.imgur.com/T2LT1pB.png", accent: "var(--crimson)" },
+  { name: "Bah Ibrahim",          bio: "Resp. des opérations",   img: "https://i.imgur.com/l3UdDov.png", accent: "var(--gold)"    },
+  { name: "Kadiatou Sow",         bio: "Secrétaire",             img: "https://i.imgur.com/THTzMBW.png", accent: "var(--emerald)" },
+  { name: "Cissé Abdoulaye",      bio: "Trésorier",              img: "https://i.imgur.com/7FduSwY.png", accent: "var(--ink)"     },
+  { name: "Francois Halleux",     bio: "Conseiller stratégique", img: "https://i.imgur.com/1qqkroP.png", accent: "var(--ink)"     },
+];
 
 const HomePage: React.FC<{ navigate: (v: ViewState) => void; language: LanguageCode }> = ({ navigate, language }) => (
   <div>
@@ -156,142 +165,196 @@ const HomePage: React.FC<{ navigate: (v: ViewState) => void; language: LanguageC
       onDonate={() => navigate(ViewState.DONATE)}
     />
 
-    {/* ── Impact numbers strip ───────────────────────────────────────────── */}
-    <div className="bg-[#0F0F0F] relative overflow-hidden">
-      {/* Flag line top */}
+    {/* ── Bandeau de chiffres ───────────────────────────────────────────── */}
+    <div className="bg-ink relative overflow-hidden">
       <div className="flag-line" aria-hidden="true"><span /><span /><span /></div>
-      <div className="max-w-7xl mx-auto px-4 sm:px-6">
-        <dl className="grid grid-cols-2 lg:grid-cols-4 divide-x divide-white/8">
+      {/* Dot-grid overlay for depth on dark background */}
+      <div className="absolute inset-0 dot-grid opacity-[0.13] pointer-events-none" aria-hidden="true" />
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 relative">
+        <dl className="grid grid-cols-2 lg:grid-cols-4 divide-x divide-white/[0.08]">
           {IMPACT_NUMBERS.map((stat) => (
-            <div key={stat.label} className="px-8 py-10 text-center">
-              <dt
-                className="text-3xl xl:text-4xl font-serif font-black leading-none"
-                style={{ color: stat.accent }}
-              >
-                {stat.value}
-              </dt>
-              <dd className="mt-2.5 text-[10px] font-bold uppercase tracking-[0.2em] text-white/40">
+            <div key={stat.label} className="px-8 py-14 text-center flex flex-col-reverse gap-3">
+              <dt className="text-label font-bold uppercase tracking-[0.2em] text-white/40">
                 {stat.label}
+              </dt>
+              <dd className="text-4xl xl:text-5xl font-serif font-black leading-none" style={{ color: stat.accent }}>
+                {stat.value}
               </dd>
             </div>
           ))}
         </dl>
       </div>
-      {/* Flag line bottom */}
       <div className="flag-line" aria-hidden="true"><span /><span /><span /></div>
     </div>
 
-    {/* ── Programs section ──────────────────────────────────────────────── */}
-    <section className="bg-[#FAFAF8] py-20 sm:py-28" aria-labelledby="programs-title">
+    {/* ── Programmes ───────────────────────────────────────────────────── */}
+    <section className="bg-ivory py-20 sm:py-28" aria-labelledby="programs-title">
       <div className="max-w-7xl mx-auto px-4 sm:px-6">
 
-        {/* Section header */}
-        <div className="max-w-2xl mb-16">
-          <p className="text-[10px] font-black uppercase tracking-[0.3em] text-[#BE0000] mb-3">
-            Nos programmes
-          </p>
-          <h2 id="programs-title" className="font-serif font-black text-3xl sm:text-4xl text-[#0F0F0F] leading-tight">
-            Du toit à l'indépendance — le parcours complet.
-          </h2>
-          <p className="mt-4 text-[#6B6B6B] text-base leading-relaxed">
-            Nous ne traitons pas les urgences une par une. Nous gérons le parcours entier : logement, droits, alimentation, emploi, communauté, culture — jusqu'à ce que la personne soit vraiment libre.
-          </p>
-        </div>
+        <SectionHeader
+          titleId="programs-title"
+          eyebrow="Nos programmes"
+          title="Du toit à l'indépendance — le parcours complet."
+          description="Nous ne traitons pas les urgences une par une. Nous gérons le parcours entier : logement, droits, alimentation, emploi, communauté, culture — jusqu'à ce que la personne soit vraiment libre."
+          flagLine
+          className="mb-16"
+        />
 
-        {/* Programs grid — cards with colored top border */}
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-          {PROGRAMS.map((prog, i) => (
-            <motion.button
+        {/* Featured layout: first card spans 2 cols, rest fills row below */}
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+
+          {/* Featured card — Droits, 2-col wide */}
+          <motion.div
+            custom={0}
+            variants={cardVariants}
+            initial="hidden"
+            whileInView="visible"
+            viewport={{ once: true, margin: '-40px' }}
+            className="lg:col-span-2"
+          >
+            <Card
+              hover
+              onClick={() => navigate(PROGRAMS[0].view)}
+              accentColor={PROGRAMS[0].borderColor}
+              className="group p-8 sm:p-10 flex flex-col gap-6 h-full"
+            >
+              <div className="flex items-start gap-6">
+                <div className={`w-14 h-14 ${PROGRAMS[0].iconBg} rounded-token-lg flex items-center justify-center shrink-0`}>
+                  <PROGRAMS[0].icon className={`h-7 w-7 ${PROGRAMS[0].iconColor}`} aria-hidden="true" />
+                </div>
+                <div className="flex-1">
+                  <h3 className="font-serif font-black text-2xl text-ink mb-3 leading-tight group-hover:opacity-80 transition-opacity">
+                    {PROGRAMS[0].label}
+                  </h3>
+                  <p className="text-body-lg text-ink-muted leading-relaxed">{PROGRAMS[0].desc}</p>
+                </div>
+              </div>
+              <div
+                className="flex items-center gap-1.5 text-label font-bold uppercase tracking-widest opacity-0 group-hover:opacity-100 transition-opacity duration-200 mt-auto"
+                style={{ color: PROGRAMS[0].borderColor }}
+              >
+                Accéder <ArrowRight className="h-3 w-3" aria-hidden="true" />
+              </div>
+            </Card>
+          </motion.div>
+
+          {/* Second card (Logement) — single column */}
+          <motion.div
+            custom={1}
+            variants={cardVariants}
+            initial="hidden"
+            whileInView="visible"
+            viewport={{ once: true, margin: '-40px' }}
+          >
+            <Card
+              hover
+              onClick={() => navigate(PROGRAMS[1].view)}
+              accentColor={PROGRAMS[1].borderColor}
+              className="group p-7 flex flex-col gap-5 h-full"
+            >
+              <div className={`w-10 h-10 ${PROGRAMS[1].iconBg} rounded-token flex items-center justify-center shrink-0`}>
+                <PROGRAMS[1].icon className={`h-5 w-5 ${PROGRAMS[1].iconColor}`} aria-hidden="true" />
+              </div>
+              <div className="flex-1">
+                <h3 className="font-serif font-black text-lg text-ink mb-2 leading-tight group-hover:opacity-80 transition-opacity">
+                  {PROGRAMS[1].label}
+                </h3>
+                <p className="text-body-sm text-ink-muted leading-relaxed">{PROGRAMS[1].desc}</p>
+              </div>
+              <div
+                className="flex items-center gap-1.5 text-label font-bold uppercase tracking-widest opacity-0 group-hover:opacity-100 transition-opacity duration-200"
+                style={{ color: PROGRAMS[1].borderColor }}
+              >
+                Accéder <ArrowRight className="h-3 w-3" aria-hidden="true" />
+              </div>
+            </Card>
+          </motion.div>
+
+          {/* Remaining 3 cards — one per column */}
+          {PROGRAMS.slice(2).map((prog, i) => (
+            <motion.div
               key={prog.view}
-              custom={i}
+              custom={i + 2}
               variants={cardVariants}
               initial="hidden"
               whileInView="visible"
               viewport={{ once: true, margin: '-40px' }}
-              onClick={() => navigate(prog.view)}
-              whileHover={{ y: -4, transition: { type: 'spring', stiffness: 350, damping: 22 } }}
-              className="group bg-white border border-[#E8E8E6] rounded-[12px] p-7 text-left flex flex-col gap-5 shadow-[0_1px_3px_rgba(0,0,0,0.04)] hover:shadow-[0_8px_24px_rgba(0,0,0,0.08)] transition-shadow focus:outline-none overflow-hidden relative"
             >
-              {/* Colored top border */}
-              <div
-                className="absolute top-0 left-0 right-0 h-[3px] rounded-t-[12px]"
-                style={{ background: prog.borderColor }}
-                aria-hidden="true"
-              />
-
-              <div className={`w-10 h-10 ${prog.iconBg} rounded-[8px] flex items-center justify-center shrink-0`}>
-                <prog.icon className={`h-5 w-5 ${prog.iconColor}`} aria-hidden="true" />
-              </div>
-
-              <div className="flex-1">
-                <h3
-                  className="font-serif font-black text-lg text-[#0F0F0F] mb-2 leading-tight transition-colors duration-200"
-                  style={{ ['--hover-color' as string]: prog.borderColor }}
+              <Card
+                hover
+                onClick={() => navigate(prog.view)}
+                accentColor={prog.borderColor}
+                className="group p-7 flex flex-col gap-5 h-full"
+              >
+                <div className={`w-10 h-10 ${prog.iconBg} rounded-token flex items-center justify-center shrink-0`}>
+                  <prog.icon className={`h-5 w-5 ${prog.iconColor}`} aria-hidden="true" />
+                </div>
+                <div className="flex-1">
+                  <h3 className="font-serif font-black text-lg text-ink mb-2 leading-tight group-hover:opacity-80 transition-opacity">
+                    {prog.label}
+                  </h3>
+                  <p className="text-body-sm text-ink-muted leading-relaxed">{prog.desc}</p>
+                </div>
+                <div
+                  className="flex items-center gap-1.5 text-label font-bold uppercase tracking-widest opacity-0 group-hover:opacity-100 transition-opacity duration-200"
+                  style={{ color: prog.borderColor }}
                 >
-                  <span className="group-hover:opacity-80 transition-opacity">{prog.label}</span>
-                </h3>
-                <p className="text-[13px] text-[#6B6B6B] leading-relaxed">{prog.desc}</p>
-              </div>
-
-              <div className="flex items-center gap-1.5 text-[10px] font-black uppercase tracking-widest opacity-0 group-hover:opacity-100 transition-opacity duration-200" style={{ color: prog.borderColor }}>
-                Accéder <ArrowRight className="h-3 w-3" aria-hidden="true" />
-              </div>
-            </motion.button>
+                  Accéder <ArrowRight className="h-3 w-3" aria-hidden="true" />
+                </div>
+              </Card>
+            </motion.div>
           ))}
         </div>
       </div>
     </section>
 
-    {/* ── Donate CTA ────────────────────────────────────────────────────── */}
-    <section className="bg-white py-16 border-t border-[#E8E8E6]" aria-label="Soutenir Ballal ASBL">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 flex flex-col sm:flex-row items-center justify-between gap-8">
-        <div>
-          <p className="text-[10px] font-black uppercase tracking-[0.3em] text-[#6B6B6B] mb-2">Agir maintenant</p>
-          <h2 className="font-serif font-black text-2xl text-[#0F0F0F]">
-            Soutenir Ballal, c'est soutenir ceux qui savent.
-          </h2>
-          <p className="text-[13px] text-[#6B6B6B] mt-1.5">
-            Une association de terrain, par et pour les sans-papiers. Chaque don finance directement le parcours vers l'indépendance.
-          </p>
+    {/* ── CTA Don — section signature en jaune Guinée ──────────────────── */}
+    <section className="bg-guinea-yellow relative overflow-hidden py-16 sm:py-20" aria-label="Soutenir Ballal ASBL">
+      {/* Decorative background elements */}
+      <div className="absolute -right-28 -bottom-28 w-[380px] h-[380px] bg-ink/[0.04] rounded-full pointer-events-none" aria-hidden="true" />
+      <div className="absolute -left-14 -top-14 w-44 h-44 bg-guinea-red/[0.08] rounded-full pointer-events-none" aria-hidden="true" />
+      <div className="absolute right-1/4 top-0 w-px h-full bg-ink/[0.06] pointer-events-none" aria-hidden="true" />
+
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 relative z-10">
+        <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-8">
+          <div className="max-w-xl">
+            <p className="text-label font-bold uppercase tracking-[0.3em] text-ink/50 mb-3">Agir maintenant</p>
+            <h2 className="font-serif font-black text-3xl sm:text-4xl text-ink leading-tight">
+              Soutenir Ballal, c'est soutenir ceux qui savent.
+            </h2>
+            <p className="text-body-sm text-ink/70 mt-3 leading-relaxed">
+              Une association de terrain, par et pour les sans-papiers. Chaque don finance directement le parcours vers l'indépendance.
+            </p>
+          </div>
+          <motion.button
+            onClick={() => navigate(ViewState.DONATE)}
+            whileHover={{ scale: 1.02 }}
+            whileTap={{ scale: 0.97 }}
+            transition={{ type: 'spring', stiffness: 400, damping: 25 }}
+            className="shrink-0 inline-flex items-center gap-2.5 px-7 py-3.5 bg-ink text-white text-[12px] font-bold uppercase tracking-widest rounded-token hover:bg-guinea-red transition-colors duration-200 group focus:outline-none focus-visible:ring-2 focus-visible:ring-ink/40 focus-visible:ring-offset-2"
+          >
+            Soutenir Ballal
+            <ArrowRight className="h-4 w-4 group-hover:translate-x-0.5 transition-transform" aria-hidden="true" />
+          </motion.button>
         </div>
-        <motion.button
-          onClick={() => navigate(ViewState.DONATE)}
-          whileHover={{ scale: 1.02 }}
-          whileTap={{ scale: 0.97 }}
-          transition={{ type: 'spring', stiffness: 400, damping: 25 }}
-          className="shrink-0 inline-flex items-center gap-2.5 px-7 py-3.5 bg-[#0F0F0F] text-white text-[12px] font-black uppercase tracking-widest rounded-[8px] hover:bg-[#BE0000] transition-colors duration-200 group focus:outline-none"
-        >
-          Soutenir Ballal
-          <ArrowRight className="h-4 w-4 group-hover:translate-x-0.5 transition-transform" aria-hidden="true" />
-        </motion.button>
       </div>
     </section>
 
     {/* ── Conseil d'Administration ──────────────────────────────────────── */}
-    <section className="bg-[#FAFAF8] py-20 sm:py-28 border-t border-[#E8E8E6]" aria-labelledby="team-title">
+    <section className="bg-ivory py-20 sm:py-28 border-t border-border-subtle" aria-labelledby="team-title">
       <div className="max-w-7xl mx-auto px-4 sm:px-6">
 
-        <div className="max-w-2xl mb-14">
-          <p className="text-[10px] font-black uppercase tracking-[0.3em] text-[#BE0000] mb-3">
-            Gouvernance
-          </p>
-          <h2 id="team-title" className="font-serif font-black text-3xl sm:text-4xl text-[#0F0F0F] leading-tight">
-            Conseil d'Administration
-          </h2>
-          <p className="mt-3 text-[#6B6B6B] text-base">
-            Notre direction vient de la rue. Certains ont été sans-papiers. Tous ont vécu ce que vivent nos bénéficiaires. C'est ce qui fait notre différence.
-          </p>
-        </div>
+        <SectionHeader
+          titleId="team-title"
+          eyebrow="Gouvernance"
+          title="Conseil d'Administration"
+          description="Notre direction vient de la rue. Certains ont été sans-papiers. Tous ont vécu ce que vivent nos bénéficiaires. C'est ce qui fait notre différence."
+          flagLine
+          className="mb-14"
+        />
 
-        {/* Admin cards */}
         <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-4 sm:gap-5">
-          {[
-            { name: "Thierno I. T. Diallo", bio: "Président fondateur",    img: "https://i.imgur.com/T2LT1pB.png", accent: "#BE0000" },
-            { name: "Bah Ibrahim",          bio: "Resp. des opérations",   img: "https://i.imgur.com/l3UdDov.png", accent: "#FFCC00" },
-            { name: "Kadiatou Sow",         bio: "Secrétaire",             img: "https://i.imgur.com/THTzMBW.png", accent: "#00843D" },
-            { name: "Cissé Abdoulaye",      bio: "Trésorier",              img: "https://i.imgur.com/7FduSwY.png", accent: "#0F0F0F" },
-            { name: "Francois Halleux",     bio: "Conseiller stratégique", img: "https://i.imgur.com/1qqkroP.png", accent: "#2563EB" },
-          ].map((member, i) => (
+          {TEAM_MEMBERS.map((member, i) => (
             <motion.div
               key={member.name}
               custom={i}
@@ -299,40 +362,40 @@ const HomePage: React.FC<{ navigate: (v: ViewState) => void; language: LanguageC
               initial="hidden"
               whileInView="visible"
               viewport={{ once: true, margin: '-30px' }}
-              className="bg-white rounded-[12px] overflow-hidden border border-[#E8E8E6] shadow-[0_1px_3px_rgba(0,0,0,0.04)] hover:shadow-[0_4px_16px_rgba(0,0,0,0.08)] transition-shadow group"
             >
-              <div className="relative aspect-[3/4] overflow-hidden bg-[#F0F0EE]">
-                <img
-                  src={member.img}
-                  alt={member.name}
-                  className="w-full h-full object-cover grayscale group-hover:grayscale-0 transition-all duration-500 group-hover:scale-105"
-                  loading="lazy"
-                />
-                <div
-                  className="absolute bottom-0 left-0 right-0 h-[3px]"
-                  style={{ backgroundColor: member.accent }}
-                  aria-hidden="true"
-                />
-              </div>
-              <div className="p-4">
-                <p className="font-black text-[13px] text-[#0F0F0F] leading-tight">{member.name}</p>
-                <p className="text-[10px] text-[#6B6B6B] font-medium mt-1">{member.bio}</p>
-              </div>
+              <Card className="group overflow-hidden">
+                <div className="relative aspect-[3/4] overflow-hidden bg-border-subtle">
+                  <img
+                    src={member.img}
+                    alt={member.name}
+                    className="w-full h-full object-cover grayscale group-hover:grayscale-0 transition-all duration-500 group-hover:scale-105"
+                    loading="lazy"
+                  />
+                  <div
+                    className="absolute bottom-0 left-0 right-0 h-[3px]"
+                    style={{ backgroundColor: member.accent }}
+                    aria-hidden="true"
+                  />
+                </div>
+                <div className="p-4">
+                  <p className="font-black text-body-sm text-ink leading-tight">{member.name}</p>
+                  <p className="text-label text-ink-muted font-medium mt-1">{member.bio}</p>
+                </div>
+              </Card>
             </motion.div>
           ))}
         </div>
 
-        {/* Members collective photo */}
-        <div className="mt-12 rounded-[20px] overflow-hidden relative shadow-[0_8px_32px_rgba(0,0,0,0.08)]">
+        <div className="mt-12 rounded-token-xl overflow-hidden relative shadow-soft-lg">
           <img
             src="https://i.imgur.com/CwnDz75.png"
             alt="Membres et militants de Ballal ASBL"
             className="w-full h-64 sm:h-80 object-cover"
             loading="lazy"
           />
-          <div className="absolute inset-0 bg-gradient-to-t from-[#0F0F0F]/80 via-[#0F0F0F]/20 to-transparent" aria-hidden="true" />
+          <div className="absolute inset-0 bg-gradient-to-t from-ink/80 via-ink/20 to-transparent" aria-hidden="true" />
           <div className="absolute bottom-0 left-0 right-0 p-6 sm:p-8">
-            <p className="text-[10px] font-black uppercase tracking-[0.3em] text-[#FFCC00] mb-2">Membres & Militants</p>
+            <p className="text-label font-black uppercase tracking-[0.3em] text-guinea-yellow mb-2">Membres & Militants</p>
             <p className="font-serif font-black text-xl sm:text-2xl text-white leading-snug max-w-xl">
               Derrière chaque action Ballal, des femmes et des hommes qui ne lâchent pas.
             </p>
@@ -368,7 +431,7 @@ const AppContent: React.FC = () => {
   };
 
   return (
-    <div className="min-h-screen bg-[#FAFAF8] text-[#0F0F0F]">
+    <div className="min-h-screen bg-ivory text-ink">
       <Navbar
         setView={navigate}
         language={language}
@@ -376,7 +439,7 @@ const AppContent: React.FC = () => {
         onOpenAuth={() => openAuth('login')}
       />
 
-      {/* pt accounts for: 3px flag line + 68px nav */}
+      {/* pt-[71px] = 3px flag-line + 68px nav */}
       <main id="main-content" className="pt-[71px]">
         <ErrorBoundary>
           <Routes>

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -10,90 +10,101 @@ interface HeroProps {
   onDonate: () => void;
 }
 
-const STATS = [
-  { value: 'Fondée',   label: 'par des sans-papiers' },
-  { value: '2022',     label: 'Molenbeek, Bruxelles' },
-  { value: 'Du toit',  label: "jusqu'à l'autonomie" },
-];
+const ease = [0.22, 1, 0.36, 1] as const;
 
-const containerVariants = {
-  hidden: {},
-  visible: { transition: { staggerChildren: 0.12, delayChildren: 0.15 } },
-};
-const wordVariants = {
-  hidden:  { opacity: 0, y: 24 },
-  visible: { opacity: 1, y: 0, transition: { duration: 0.5, ease: [0.22, 1, 0.36, 1] as const } },
-};
 const fadeUp = {
-  hidden:  { opacity: 0, y: 16 },
+  hidden:  { opacity: 0, y: 18 },
   visible: (delay: number = 0) => ({
     opacity: 1, y: 0,
-    transition: { duration: 0.5, ease: [0.22, 1, 0.36, 1] as const, delay },
+    transition: { duration: 0.45, ease, delay },
   }),
 };
 
 const Hero: React.FC<HeroProps> = ({ onExplore, onDonate }) => {
   return (
     <section
-      className="relative bg-[#FAFAF8] overflow-hidden"
+      className="relative bg-ivory overflow-hidden"
       aria-label="Présentation de Ballal ASBL"
       id="hero"
     >
-      {/* Subtle warm gradient — right side */}
-      <div className="absolute top-0 right-0 w-2/5 h-full pointer-events-none" aria-hidden="true">
-        <div className="absolute inset-0 bg-gradient-to-l from-[#FAFAF8] via-[#F5F0EE] to-transparent" />
-        <div className="absolute top-1/4 right-0 w-80 h-80 bg-[#BE0000]/4 rounded-full blur-[100px]" />
-        <div className="absolute bottom-1/4 right-16 w-56 h-56 bg-[#00843D]/4 rounded-full blur-[80px]" />
+      {/* Dot-grid texture — adds atmospheric depth */}
+      <div className="absolute inset-0 dot-grid pointer-events-none" aria-hidden="true" />
+
+      {/* Vertical Guinea flag strip — left-edge signature */}
+      <div className="absolute left-0 top-0 bottom-0 w-[5px] flex flex-col z-20 pointer-events-none" aria-hidden="true">
+        <span className="flex-1 bg-guinea-red" />
+        <span className="flex-1 bg-guinea-yellow" />
+        <span className="flex-1 bg-guinea-green" />
       </div>
 
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 relative z-10">
-        <div className="grid lg:grid-cols-2 gap-12 xl:gap-20 items-center min-h-[92vh] py-20 lg:py-28">
+      {/* Color atmosphere blobs */}
+      <div className="absolute top-0 right-0 w-[55%] h-full pointer-events-none" aria-hidden="true">
+        <div className="absolute top-1/4 right-8 w-[480px] h-[480px] bg-guinea-red/[0.07] rounded-full blur-[130px]" />
+        <div className="absolute bottom-1/3 right-1/3 w-72 h-72 bg-guinea-green/[0.05] rounded-full blur-[90px]" />
+        <div className="absolute top-1/2 right-0 w-80 h-80 bg-guinea-yellow/[0.09] rounded-full blur-[110px]" />
+      </div>
+
+      <div className="max-w-7xl mx-auto px-6 sm:px-8 relative z-10">
+        <div className="grid lg:grid-cols-[1fr_440px] xl:grid-cols-[1fr_520px] gap-12 xl:gap-16 items-center min-h-[92dvh] py-20 lg:py-24">
 
           {/* LEFT — Content */}
-          <div className="space-y-10">
+          <div className="space-y-8 pl-3">
 
             {/* Status badge */}
             <motion.div
-              custom={0}
+              custom={0.1}
               variants={fadeUp}
               initial="hidden"
               animate="visible"
-              className="inline-flex items-center gap-2 text-[10px] font-black uppercase tracking-[0.28em] text-[#BE0000]/80"
+              className="inline-flex items-center gap-2 text-[10px] font-bold uppercase tracking-[0.28em] text-guinea-red/80"
             >
-              <span className="w-1.5 h-1.5 rounded-full bg-[#BE0000] animate-pulse" aria-hidden="true" />
+              <span className="w-1.5 h-1.5 rounded-full bg-guinea-red animate-pulse" aria-hidden="true" />
               ASBL agréée · BCE 1016.925.333 · Bruxelles
             </motion.div>
 
-            {/* Headline — staggered word reveal */}
-            <motion.div
-              variants={containerVariants}
-              initial="hidden"
-              animate="visible"
+            {/* Headline — three staggered lines in one h1 */}
+            <motion.h1
+              className="font-serif font-black leading-[0.92] tracking-tight"
               aria-label="Accueillir. Défendre. Rassembler."
             >
-              {['Accueillir.', 'Défendre.', 'Rassembler.'].map((word, i) => (
-                <motion.div
-                  key={word}
-                  variants={wordVariants}
-                >
-                  <h1
-                    className={`font-serif font-black leading-[1.0] tracking-tight text-5xl sm:text-6xl xl:text-7xl ${
-                      i === 1 ? 'text-[#BE0000]' : 'text-[#0F0F0F]'
-                    }`}
-                  >
-                    {word}
-                  </h1>
-                </motion.div>
-              ))}
-            </motion.div>
+              <motion.span
+                className="block text-5xl sm:text-6xl xl:text-[80px] text-ink"
+                custom={0.2}
+                variants={fadeUp}
+                initial="hidden"
+                animate="visible"
+              >
+                Accueillir.
+              </motion.span>
 
-            {/* Mission */}
+              <motion.span
+                className="block italic text-5xl sm:text-6xl xl:text-[80px] text-guinea-red"
+                custom={0.32}
+                variants={fadeUp}
+                initial="hidden"
+                animate="visible"
+              >
+                Défendre.
+              </motion.span>
+
+              <motion.span
+                className="block text-5xl sm:text-6xl xl:text-[80px] text-ink"
+                custom={0.44}
+                variants={fadeUp}
+                initial="hidden"
+                animate="visible"
+              >
+                <span className="highlight-mark">Rassembler.</span>
+              </motion.span>
+            </motion.h1>
+
+            {/* Mission paragraph */}
             <motion.p
-              custom={0.5}
+              custom={0.55}
               variants={fadeUp}
               initial="hidden"
               animate="visible"
-              className="text-[17px] text-[#6B6B6B] leading-[1.75] max-w-lg font-medium"
+              className="text-body-lg text-ink-muted leading-[1.75] max-w-lg"
             >
               Ballal n'est pas une association qui vous aide de l'extérieur.
               Nous sommes des sans-papiers et d'anciens sans-papiers qui prennent
@@ -114,7 +125,7 @@ const Hero: React.FC<HeroProps> = ({ onExplore, onDonate }) => {
                 whileHover={{ scale: 1.02 }}
                 whileTap={{ scale: 0.97 }}
                 transition={{ type: 'spring', stiffness: 400, damping: 25 }}
-                className="inline-flex items-center gap-2.5 px-7 py-3.5 bg-[#BE0000] text-white text-[12px] font-black uppercase tracking-widest rounded-[8px] shadow-[0_4px_16px_rgba(190,0,0,0.25)] hover:bg-[#9B0000] transition-colors duration-200 group focus:outline-none"
+                className="inline-flex items-center gap-2.5 px-7 py-3.5 bg-guinea-red text-white text-[12px] font-bold uppercase tracking-widest rounded-token shadow-[0_4px_20px_rgba(190,0,0,0.28)] hover:bg-guinea-red-dark transition-colors duration-200 group focus:outline-none focus-visible:ring-2 focus-visible:ring-guinea-red/50 focus-visible:ring-offset-2"
               >
                 Rejoindre le combat
                 <ArrowRight className="h-4 w-4 group-hover:translate-x-0.5 transition-transform" aria-hidden="true" />
@@ -125,32 +136,36 @@ const Hero: React.FC<HeroProps> = ({ onExplore, onDonate }) => {
                 whileHover={{ scale: 1.02 }}
                 whileTap={{ scale: 0.97 }}
                 transition={{ type: 'spring', stiffness: 400, damping: 25 }}
-                className="inline-flex items-center gap-2.5 px-7 py-3.5 border border-[#0F0F0F] text-[#0F0F0F] text-[12px] font-black uppercase tracking-widest rounded-[8px] hover:bg-[#0F0F0F] hover:text-white transition-colors duration-200 group focus:outline-none"
+                className="inline-flex items-center gap-2.5 px-7 py-3.5 border-2 border-ink text-ink text-[12px] font-bold uppercase tracking-widest rounded-token hover:bg-ink hover:text-white transition-colors duration-200 group focus:outline-none focus-visible:ring-2 focus-visible:ring-ink/40 focus-visible:ring-offset-2"
               >
-                <Heart className="h-4 w-4 text-[#BE0000] fill-[#BE0000] group-hover:text-[#FFCC00] group-hover:fill-[#FFCC00] transition-colors" aria-hidden="true" />
+                <Heart className="h-4 w-4 text-guinea-red fill-guinea-red group-hover:text-guinea-yellow group-hover:fill-guinea-yellow transition-colors" aria-hidden="true" />
                 Soutenir Ballal
               </motion.button>
             </motion.div>
 
-            {/* Stats row with colored vertical bars */}
+            {/* Stat bars */}
             <motion.div
-              custom={0.8}
+              custom={0.78}
               variants={fadeUp}
               initial="hidden"
               animate="visible"
-              className="pt-6 border-t border-[#E8E8E6]"
+              className="pt-6 border-t border-border-subtle"
             >
               <div className="flex flex-wrap gap-8">
-                {STATS.map((stat, i) => (
+                {[
+                  { value: 'Fondée',   label: 'par des sans-papiers', color: '#BE0000' },
+                  { value: '2022',     label: 'Molenbeek, Bruxelles', color: '#FFCC00' },
+                  { value: 'Du toit',  label: "jusqu'à l'autonomie",  color: '#00843D' },
+                ].map((stat) => (
                   <div key={stat.label} className="flex items-start gap-3">
                     <div
                       className="w-[3px] h-10 rounded-full shrink-0 mt-0.5"
-                      style={{ background: ['#BE0000', '#FFCC00', '#00843D'][i] }}
+                      style={{ background: stat.color }}
                       aria-hidden="true"
                     />
                     <div>
-                      <p className="text-[17px] font-black text-[#0F0F0F] leading-none tracking-tight">{stat.value}</p>
-                      <p className="text-[10px] text-[#6B6B6B] font-medium mt-1 uppercase tracking-[0.14em]">{stat.label}</p>
+                      <p className="text-[17px] font-bold text-ink leading-none tracking-tight">{stat.value}</p>
+                      <p className="text-[10px] text-ink-muted font-medium mt-1 uppercase tracking-[0.14em]">{stat.label}</p>
                     </div>
                   </div>
                 ))}
@@ -160,71 +175,76 @@ const Hero: React.FC<HeroProps> = ({ onExplore, onDonate }) => {
 
           {/* RIGHT — Visual */}
           <motion.div
-            initial={{ opacity: 0, x: 32 }}
+            initial={{ opacity: 0, x: 28 }}
             animate={{ opacity: 1, x: 0 }}
-            transition={{ duration: 0.7, ease: [0.22, 1, 0.36, 1], delay: 0.2 }}
+            transition={{ duration: 0.6, ease, delay: 0.25 }}
             className="relative flex justify-center lg:justify-end"
           >
-            <div className="relative w-full max-w-md xl:max-w-lg">
+            <div className="relative w-full max-w-[420px] xl:max-w-[520px]">
 
-              {/* Offset border accent */}
+              {/* Rotated yellow accent border */}
               <div
-                className="absolute inset-0 translate-x-3 translate-y-3 border border-[#BE0000]/20 rounded-[20px]"
+                className="absolute inset-0 rotate-2 border-2 border-guinea-yellow/65 rounded-[22px]"
                 aria-hidden="true"
               />
 
-              {/* Main image */}
-              <div className="relative bg-[#E8E8E6] rounded-[20px] overflow-hidden aspect-[4/5] shadow-[0_16px_48px_rgba(0,0,0,0.10),0_4px_12px_rgba(0,0,0,0.05)]">
+              {/* Green corner accent */}
+              <div
+                className="absolute -right-3 -top-3 w-14 h-14 bg-guinea-green/20 rounded-token-lg"
+                aria-hidden="true"
+              />
+
+              {/* Main image — subtly tilted */}
+              <div className="relative bg-border-subtle rounded-[20px] overflow-hidden aspect-[4/5] shadow-soft-xl -rotate-[1.5deg]">
                 <img
                   src="https://i.imgur.com/laZeGp9.jpeg"
                   className="w-full h-full object-cover"
                   alt="Membres de la communauté Ballal ASBL à Bruxelles"
                   loading="eager"
                 />
-                <div className="absolute inset-0 bg-gradient-to-t from-[#0F0F0F]/70 via-[#0F0F0F]/10 to-transparent" aria-hidden="true" />
+                <div className="absolute inset-0 bg-gradient-to-t from-ink/72 via-ink/10 to-transparent" aria-hidden="true" />
 
                 <blockquote className="absolute bottom-0 left-0 right-0 p-6">
-                  <p className="font-serif italic text-white text-lg leading-snug drop-shadow">
-                    "On vient de là où tu viens. Et on ne lâche pas."
+                  <p className="font-serif italic text-white text-lg leading-snug drop-shadow-md">
+                    « On vient de là où tu viens. Et on ne lâche pas. »
                   </p>
-                  {/* Flag line as quote underline */}
-                  <div className="flex gap-0.5 mt-3" aria-hidden="true">
-                    <span className="h-[2px] w-6 bg-[#BE0000] rounded-full" />
-                    <span className="h-[2px] w-6 bg-[#FFCC00] rounded-full" />
-                    <span className="h-[2px] w-6 bg-[#00843D] rounded-full" />
+                  <div className="flex gap-1 mt-3" aria-hidden="true">
+                    <span className="h-[3px] w-8 bg-guinea-red rounded-full" />
+                    <span className="h-[3px] w-8 bg-guinea-yellow rounded-full" />
+                    <span className="h-[3px] w-8 bg-guinea-green rounded-full" />
                   </div>
                 </blockquote>
               </div>
 
-              {/* Bottom badge */}
+              {/* Bottom floating badge */}
               <motion.div
                 initial={{ opacity: 0, y: 12 }}
                 animate={{ opacity: 1, y: 0 }}
-                transition={{ delay: 0.7, duration: 0.4, ease: 'easeOut' }}
-                className="absolute -bottom-4 -left-4 bg-white border border-[#E8E8E6] rounded-[12px] shadow-[0_4px_16px_rgba(0,0,0,0.08)] px-4 py-3 flex items-center gap-3"
+                transition={{ delay: 0.78, duration: 0.35, ease: 'easeOut' }}
+                className="absolute -bottom-5 -left-5 bg-white border border-border-subtle rounded-token-lg shadow-soft-lg px-4 py-3 flex items-center gap-3"
                 aria-hidden="true"
               >
-                <div className="flex flex-col gap-[2px]">
-                  <span className="block w-2 h-5 bg-[#BE0000] rounded-sm" />
-                  <span className="block w-2 h-5 bg-[#FFCC00] rounded-sm" />
-                  <span className="block w-2 h-5 bg-[#00843D] rounded-sm" />
+                <div className="flex flex-col gap-[3px] shrink-0">
+                  <span className="block w-2 h-5 bg-guinea-red rounded-sm" />
+                  <span className="block w-2 h-5 bg-guinea-yellow rounded-sm" />
+                  <span className="block w-2 h-5 bg-guinea-green rounded-sm" />
                 </div>
                 <div>
-                  <p className="text-[10px] font-black uppercase tracking-widest text-[#0F0F0F]">Guinée · Belgique</p>
-                  <p className="text-[9px] text-[#6B6B6B] font-medium mt-0.5">Par les sans-papiers, pour les sans-papiers</p>
+                  <p className="text-[10px] font-bold uppercase tracking-widest text-ink">Guinée · Belgique</p>
+                  <p className="text-[9px] text-ink-muted font-medium mt-0.5">Par les sans-papiers, pour les sans-papiers</p>
                 </div>
               </motion.div>
 
-              {/* Top badge */}
+              {/* Top floating badge */}
               <motion.div
                 initial={{ opacity: 0, y: -12 }}
                 animate={{ opacity: 1, y: 0 }}
-                transition={{ delay: 0.8, duration: 0.4, ease: 'easeOut' }}
-                className="absolute -top-4 -right-4 bg-[#BE0000] text-white rounded-[12px] shadow-[0_4px_16px_rgba(190,0,0,0.25)] px-4 py-3 text-center"
+                transition={{ delay: 0.82, duration: 0.35, ease: 'easeOut' }}
+                className="absolute -top-5 -right-5 bg-guinea-red text-white rounded-token-lg shadow-[0_4px_20px_rgba(190,0,0,0.3)] px-4 py-3 text-center"
                 aria-hidden="true"
               >
-                <p className="text-[9px] font-black uppercase tracking-widest opacity-75">ASBL</p>
-                <p className="text-[10px] font-black mt-0.5">Agréée</p>
+                <p className="text-[9px] font-bold uppercase tracking-widest opacity-75">ASBL</p>
+                <p className="text-[10px] font-bold mt-0.5">Agréée</p>
               </motion.div>
             </div>
           </motion.div>

--- a/index.css
+++ b/index.css
@@ -5,5 +5,7 @@
 /* Global styles */
 body {
     margin: 0;
-    font-family: sans-serif;
+    font-family: 'Syne', sans-serif;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
 }

--- a/index.html
+++ b/index.html
@@ -32,29 +32,36 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,700;0,900;1,700&family=Plus+Jakarta+Sans:wght@400;500;600;700;800&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300..900;1,9..144,300..900&family=Syne:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
 
-    <!-- Tailwind CDN (dev fallback — Vite uses PostCSS in production) -->
+    <!-- Tailwind CDN — moteur de styles en production (JIT via MutationObserver) -->
     <script src="https://cdn.tailwindcss.com"></script>
     <script>
       tailwind.config = {
         theme: {
           extend: {
             colors: {
-              'guinea-red':    '#BE0000',
-              'guinea-yellow': '#FFCC00',
-              'guinea-green':  '#00843D',
-              'ivory':         '#FAFAF8',
-              'ink':           '#0F0F0F',
-              'earth-black':   '#1C1C1E',
-              'soft-paper':    '#FAFAF8',
-              'terracotta':    '#C9614A',
+              'guinea-red':      '#BE0000',
+              'guinea-red-dark': '#9B0000',
+              'guinea-yellow':   '#FFCC00',
+              'guinea-green':    '#00843D',
+              'ivory':           '#FAFAF8',
+              'ink':             '#0F0F0F',
+              'ink-muted':       '#6B6B6B',
+              'border-subtle':   '#E8E8E6',
             },
             fontFamily: {
-              sans:  ['Plus Jakarta Sans', 'sans-serif'],
-              serif: ['Playfair Display', 'serif'],
+              sans:  ['Syne', 'sans-serif'],
+              serif: ['Fraunces', 'serif'],
+            },
+            fontSize: {
+              'caption': ['9px',  { lineHeight: '1.4', letterSpacing: '0.06em' }],
+              'label':   ['10px', { lineHeight: '1.4', letterSpacing: '0.28em' }],
+              'badge':   ['11px', { lineHeight: '1.4', letterSpacing: '0.14em' }],
+              'body-sm': ['13px', { lineHeight: '1.6' }],
+              'body-lg': ['17px', { lineHeight: '1.75' }],
             },
             boxShadow: {
               'soft-elegant': '0 1px 3px rgba(0,0,0,0.05), 0 4px 16px rgba(0,0,0,0.06)',
@@ -66,6 +73,20 @@
               'token':    '8px',
               'token-lg': '12px',
               'token-xl': '20px',
+            },
+            keyframes: {
+              'fade-in': {
+                '0%':   { opacity: '0', transform: 'translateY(12px)' },
+                '100%': { opacity: '1', transform: 'translateY(0)' },
+              },
+              'slide-in-right': {
+                '0%':   { opacity: '0', transform: 'translateX(24px)' },
+                '100%': { opacity: '1', transform: 'translateX(0)' },
+              },
+            },
+            animation: {
+              'fade-in':        'fade-in 0.4s ease-out forwards',
+              'slide-in-right': 'slide-in-right 0.35s ease-out forwards',
             },
           },
         },
@@ -114,25 +135,9 @@
         flex: 1;
         display: block;
       }
-      .flag-line--crimson > span:nth-child(1) { background: var(--crimson); }
-      .flag-line--crimson > span:nth-child(2) { background: var(--gold); }
-      .flag-line--crimson > span:nth-child(3) { background: var(--emerald); }
-
-      /* Thin decorative line variant (1px) */
-      .flag-line-sm {
-        display: flex;
-        width: 100%;
-        height: 1.5px;
-      }
-      .flag-line-sm > span { flex: 1; display: block; }
-      .flag-line-sm > span:nth-child(1) { background: var(--crimson); }
-      .flag-line-sm > span:nth-child(2) { background: var(--gold); }
-      .flag-line-sm > span:nth-child(3) { background: var(--emerald); }
-
-      /* ── African pattern (ultra-subtle) ─────────────── */
-      .african-pattern {
-        background-image: url("data:image/svg+xml,%3Csvg width='80' height='80' viewBox='0 0 80 80' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M40 40c0-22.09 17.91-40 40-40v80c-22.09 0-40-17.91-40-40zM0 0c22.09 0 40 17.91 40 40S22.09 80 0 80V0z' fill='%23BE0000' fill-opacity='0.006' fill-rule='evenodd'/%3E%3C/svg%3E");
-      }
+      .flag-line > span:nth-child(1) { background: var(--crimson); }
+      .flag-line > span:nth-child(2) { background: var(--gold); }
+      .flag-line > span:nth-child(3) { background: var(--emerald); }
 
       /* ── WCAG skip-to-content ───────────────────────── */
       .sr-only {
@@ -148,6 +153,18 @@
 
       /* ── Framer-motion helpers ──────────────────────── */
       [data-motion-safe] { will-change: transform, opacity; }
+
+      /* ── Dot-grid texture for atmospheric depth ─────── */
+      .dot-grid {
+        background-image: radial-gradient(circle, rgba(15,15,15,0.065) 1px, transparent 1px);
+        background-size: 22px 22px;
+      }
+
+      /* ── Yellow highlighter on inline text ──────────── */
+      .highlight-mark {
+        background: linear-gradient(transparent 58%, var(--gold) 58%);
+        padding-right: 4px;
+      }
     </style>
 
     <!-- JSON-LD structured data — Organization (Schema.org) -->


### PR DESCRIPTION
Changes from this PR were applied manually to `main` due to merge conflicts (branch was created against a much older version of main). All redesign changes are now live on main:\n\n- SectionHeader.tsx tokenized (hex → Tailwind design tokens)\n- index.html: Fraunces + Syne fonts, `.dot-grid` and `.highlight-mark` CSS utilities\n- index.css: Syne font applied globally\n- Hero.tsx: dramatic redesign with Guinea flag strip, dot-grid texture, staggered headlines, tilted image\n- App.tsx: featured programme layout, yellow CTA section, flagLine prop, Analytics + SpeedInsights\n\nClosing as superseded.